### PR TITLE
chore: optimize webpack config using html bundler plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,10 +18,8 @@
         "eslint": "^8.57.0",
         "eslint-plugin-import": "^2.29.1",
         "file-loader": "^6.2.0",
-        "html-loader": "^5.0.0",
-        "html-webpack-plugin": "^5.6.0",
+        "html-bundler-webpack-plugin": "^3.11.0",
         "image-webpack-loader": "^8.1.0",
-        "mini-css-extract-plugin": "^2.9.0",
         "purgecss-webpack-plugin": "^6.0.0",
         "raw-loader": "^4.0.2",
         "sass": "^1.76.0",
@@ -32,8 +30,7 @@
         "webpack": "^5.91.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.0.4",
-        "webpack-merge": "^5.10.0",
-        "webpack-remove-empty-scripts": "^1.0.4"
+        "webpack-merge": "^5.10.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -548,12 +545,6 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/html-minifier-terser": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
-      "integrity": "sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==",
-      "dev": true
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
@@ -1262,19 +1253,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/ansis": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-1.5.2.tgz",
-      "integrity": "sha512-T3vUABrcgSj/HXv27P+A/JxGk5b/ydx0JjN3lgjBTC2iZUFxQGjh43zCzLSbU4C1QTgmx9oaPeWNJFM+auI8qw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "type": "patreon",
-        "url": "https://patreon.com/biodiscus"
       }
     },
     "node_modules/anymatch": {
@@ -2806,6 +2784,7 @@
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
       "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^6.0.1",
@@ -3545,20 +3524,12 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/dom-converter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
-      "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
-      "dev": true,
-      "dependencies": {
-        "utila": "~0.4"
-      }
-    },
     "node_modules/dom-serializer": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
       "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
@@ -3573,6 +3544,7 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
       "dev": true,
+      "optional": true,
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -3594,6 +3566,7 @@
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
       "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "domelementtype": "^2.2.0"
       },
@@ -3609,6 +3582,7 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
       "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -4247,6 +4221,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eta": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-3.4.0.tgz",
+      "integrity": "sha512-tCsc7WXTjrTx4ZjYLplcqrI3o4mYJ+Z6YspeuGL8tbt/hHoMchwBwtKfwM09svEY86iRapY93vUqQttcNuIO5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/eta-dev/eta?sponsor=1"
       }
     },
     "node_modules/etag": {
@@ -5497,15 +5483,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true,
-      "bin": {
-        "he": "bin/he"
-      }
-    },
     "node_modules/hpack.js": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
@@ -5516,6 +5493,94 @@
         "obuf": "^1.0.0",
         "readable-stream": "^2.0.1",
         "wbuf": "^1.1.0"
+      }
+    },
+    "node_modules/html-bundler-webpack-plugin": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/html-bundler-webpack-plugin/-/html-bundler-webpack-plugin-3.11.0.tgz",
+      "integrity": "sha512-ARRGyIRdW8CO6gbGbm+BA+72Wbqx3cJqGh2ooMjarqZj7bZVvvlTk6bDMGcu4mn8WK8hMZCwKDtZM6C6te+UZg==",
+      "dev": true,
+      "dependencies": {
+        "@types/html-minifier-terser": "^7.0.2",
+        "ansis": "2.0.3",
+        "enhanced-resolve": ">=5.7.0",
+        "eta": "^3.1.1",
+        "html-minifier-terser": "^7.2.0"
+      },
+      "engines": {
+        "node": ">=14.21.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://patreon.com/biodiscus"
+      },
+      "peerDependencies": {
+        "ejs": ">=3.1.9",
+        "favicons": ">=7.1.4",
+        "handlebars": ">=4.7.7",
+        "liquidjs": ">=10.7.0",
+        "markdown-it": ">=12",
+        "mustache": ">=4.2.0",
+        "nunjucks": ">=3.2.3",
+        "parse5": ">=7.1.2",
+        "prismjs": ">=1.29.0",
+        "pug": ">=3.0.2",
+        "twig": ">=1.17.1",
+        "webpack": ">=5.32.0"
+      },
+      "peerDependenciesMeta": {
+        "ejs": {
+          "optional": true
+        },
+        "favicons": {
+          "optional": true
+        },
+        "handlebars": {
+          "optional": true
+        },
+        "liquidjs": {
+          "optional": true
+        },
+        "markdown-it": {
+          "optional": true
+        },
+        "mustache": {
+          "optional": true
+        },
+        "nunjucks": {
+          "optional": true
+        },
+        "parse5": {
+          "optional": true
+        },
+        "prismjs": {
+          "optional": true
+        },
+        "pug": {
+          "optional": true
+        },
+        "twig": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/html-bundler-webpack-plugin/node_modules/@types/html-minifier-terser": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-7.0.2.tgz",
+      "integrity": "sha512-mm2HqV22l8lFQh4r2oSsOEVea+m0qqxEmwpc9kC1p/XzmjLWrReR9D/GRs8Pex2NX/imyEH9c5IU/7tMBQCHOA==",
+      "dev": true
+    },
+    "node_modules/html-bundler-webpack-plugin/node_modules/ansis": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-2.0.3.tgz",
+      "integrity": "sha512-tcSGX0mhuDFHsgRrT56xnZ9v2X+TOeKhJ75YopI5OBgyT7tGaG5m6BmeC+6KHjiucfBvUHehQMecHbULIAkFPA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://patreon.com/biodiscus"
       }
     },
     "node_modules/html-entities": {
@@ -5533,26 +5598,6 @@
           "url": "https://patreon.com/mdevils"
         }
       ]
-    },
-    "node_modules/html-loader": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-5.0.0.tgz",
-      "integrity": "sha512-puaGKdjdVVIFRtgIC2n5dt5bt0N5j6heXlAQZ4Do1MLjHmOT1gCE1Ogg7XZNeJlnOVHHsrZKGs5dfh+XwZ3XPw==",
-      "dev": true,
-      "dependencies": {
-        "html-minifier-terser": "^7.2.0",
-        "parse5": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      }
     },
     "node_modules/html-minifier-terser": {
       "version": "7.2.0",
@@ -5573,96 +5618,6 @@
       },
       "engines": {
         "node": "^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/html-webpack-plugin": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.0.tgz",
-      "integrity": "sha512-iwaY4wzbe48AfKLZ/Cc8k0L+FKG6oSNRaZ8x5A/T/IVDGyXcbHncM9TdDa93wn0FsSm82FhTKW7f3vS61thXAw==",
-      "dev": true,
-      "dependencies": {
-        "@types/html-minifier-terser": "^6.0.0",
-        "html-minifier-terser": "^6.0.2",
-        "lodash": "^4.17.21",
-        "pretty-error": "^4.0.0",
-        "tapable": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/html-webpack-plugin"
-      },
-      "peerDependencies": {
-        "@rspack/core": "0.x || 1.x",
-        "webpack": "^5.20.0"
-      },
-      "peerDependenciesMeta": {
-        "@rspack/core": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/html-webpack-plugin/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/html-webpack-plugin/node_modules/html-minifier-terser": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
-      "integrity": "sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==",
-      "dev": true,
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "clean-css": "^5.2.2",
-        "commander": "^8.3.0",
-        "he": "^1.2.0",
-        "param-case": "^3.0.4",
-        "relateurl": "^0.2.7",
-        "terser": "^5.10.0"
-      },
-      "bin": {
-        "html-minifier-terser": "cli.js"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/htmlparser2": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-      "dev": true,
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.5.2",
-        "entities": "^2.0.0"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -7069,12 +7024,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -7273,26 +7222,6 @@
       "optional": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/mini-css-extract-plugin": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.0.tgz",
-      "integrity": "sha512-Zs1YsZVfemekSZG+44vBsYTLQORkPMwnlv+aehcxK/NLKC+EGhDB39/YePYYqx/sTk6NnYpuqikhSn7+JIevTA==",
-      "dev": true,
-      "dependencies": {
-        "schema-utils": "^4.0.0",
-        "tapable": "^2.2.1"
-      },
-      "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -7971,6 +7900,8 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
       "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "entities": "^4.4.0"
       },
@@ -8967,16 +8898,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/pretty-error": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
-      "integrity": "sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.20",
-        "renderkid": "^3.0.0"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -9282,19 +9203,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/renderkid": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
-      "integrity": "sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==",
-      "dev": true,
-      "dependencies": {
-        "css-select": "^4.1.3",
-        "dom-converter": "^0.2.0",
-        "htmlparser2": "^6.1.0",
-        "lodash": "^4.17.21",
-        "strip-ansi": "^6.0.1"
       }
     },
     "node_modules/replace-ext": {
@@ -11086,12 +10994,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
-    "node_modules/utila": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
-      "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==",
-      "dev": true
-    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -11353,25 +11255,6 @@
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/webpack-remove-empty-scripts": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/webpack-remove-empty-scripts/-/webpack-remove-empty-scripts-1.0.4.tgz",
-      "integrity": "sha512-W/Vd94oNXMsQam+W9G+aAzGgFlX1aItcJpkG3byuHGDaxyK3H17oD/b5RcqS/ZHzStIKepksdLDznejDhDUs+Q==",
-      "dev": true,
-      "dependencies": {
-        "ansis": "1.5.2"
-      },
-      "engines": {
-        "node": ">=12.14"
-      },
-      "funding": {
-        "type": "patreon",
-        "url": "https://patreon.com/biodiscus"
-      },
-      "peerDependencies": {
-        "webpack": ">=5.32.0"
       }
     },
     "node_modules/webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "private": "true",
   "scripts": {
-    "start": "webpack-dev-server --config webpack.dev.js",
+    "start": "webpack serve --config webpack.dev.js",
     "build": "npm run lint && npm run build:only",
     "build:only": "NODE_ENV=production webpack --config webpack.prod.js",
     "lint": "npx eslint -c .eslintrc.js --ext .ts,.js src/",
@@ -22,10 +22,8 @@
     "eslint": "^8.57.0",
     "eslint-plugin-import": "^2.29.1",
     "file-loader": "^6.2.0",
-    "html-loader": "^5.0.0",
-    "html-webpack-plugin": "^5.6.0",
+    "html-bundler-webpack-plugin": "^3.11.0",
     "image-webpack-loader": "^8.1.0",
-    "mini-css-extract-plugin": "^2.9.0",
     "purgecss-webpack-plugin": "^6.0.0",
     "raw-loader": "^4.0.2",
     "sass": "^1.76.0",
@@ -36,7 +34,6 @@
     "webpack": "^5.91.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4",
-    "webpack-merge": "^5.10.0",
-    "webpack-remove-empty-scripts": "^1.0.4"
+    "webpack-merge": "^5.10.0"
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,10 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>space-base-defense</title>
+    <!-- relative path to SCSS source file -->
+    <link href="./scss/index.scss" rel="stylesheet" />
+    <!-- relative path to TS source file -->
+    <script src="./typescript/index.ts" defer="defer"></script>
   </head>
   <body>
     <div id="container" class="container">

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,7 +1,5 @@
 const path = require('path');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts');
+const HtmlBundlerPlugin = require('html-bundler-webpack-plugin');
 const glob = require('glob');
 const { PurgeCSSPlugin } = require('purgecss-webpack-plugin');
 
@@ -9,13 +7,8 @@ const isProduction = process.env.NODE_ENV === 'production';
 
 module.exports = {
   context: path.resolve(__dirname, 'src'),
-  entry: {
-    main: './typescript/index.ts',
-    styles: './scss/index.scss'
-  },
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: '[name].[fullhash].js'
   },
   resolve: {
     extensions: ['.js', '.ts'],
@@ -62,30 +55,25 @@ module.exports = {
       {
         test: /\.scss$/,
         use: [
-          {
-            loader: MiniCssExtractPlugin.loader,
-            options: {
-              publicPath: '/'
-            }
-          },
           'css-loader',
           'sass-loader'
         ]
       },
-      {
-        test: /\.html$/,
-        use: 'html-loader'
-      }
     ]
   },
   plugins: [
-    new HtmlWebpackPlugin({
-      template: './index.html',
+    new HtmlBundlerPlugin({
+      entry: {
+        // entrypoint is a template file containing SCSS and TS files
+        index: './index.html', // => dist/index.html
+      },
+      js: {
+        filename: '[name].[contenthash:8].js', // JS output name
+      },
+      css: {
+        filename: '[name].[contenthash:8].css', // CSS output name
+      },
     }),
-    new MiniCssExtractPlugin({
-      filename: '[name].[fullhash].css',
-    }),
-    new RemoveEmptyScriptsPlugin(),
     new PurgeCSSPlugin({
       paths: glob.sync(`${path.resolve(__dirname, 'src')}/**/*`, { nodir: true }),
     }),


### PR DESCRIPTION
Hello @tdedetd,

I'm the author of the `webpack-remove-empty-scripts` plugin used in this repository.
I will demonstrate my other [html-bundler-webpack-plugin](https://github.com/webdiscus/html-bundler-webpack-plugin) to simplify the webpack config for rendering a HTML template with assets.

The `html-bundler-webpack-plugin` replaces the functionality of the plugins and loaders:
- html-webpack-plugin
- mini-css-extract-plugin
- webpack-remove-empty-scripts
- html-loader
- style-loader
- and many other [plugins and loaders](https://github.com/tdedetd/space-base-defense/compare/main...webdiscus:space-base-defense:main#list-of-plugins).


**Note**

- a template is the entry point, not JS/TS
- source SCSS and TS can be defined directly in HTML using `<link>` and `<script>` tags.
- you can define source files of images directly in the template, the plugin resolves them automatically and replaces with output filenames
